### PR TITLE
Add support for videos using full url

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export default class Sample extends React.Component {
   render() {
     return (
       <Lightbox
-        items={[{ src: 'http://example.com/img1.jpg', type: 'image' }, { src: '[youtube-video-id]', type: 'video' }, { src: 'http://example.com/video1.mp4', type: 'video', hasFullUrl: true }]}
+        items={[{ src: 'http://example.com/img1.jpg', type: 'image' }, { src: '[youtube-video-id]', type: 'video' }, { src: 'http://example.com/video1.mp4', type: 'video'}]}
         isOpen={this.state.lightboxIsOpen}
         onClickPrev={this.gotoPrevious}
         onClickNext={this.gotoNext}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export default class Sample extends React.Component {
   render() {
     return (
       <Lightbox
-        items={[{ src: 'http://example.com/img1.jpg', type: 'image' }, { src: '[youtube-video-id]', type: 'video' }]}
+        items={[{ src: 'http://example.com/img1.jpg', type: 'image' }, { src: '[youtube-video-id]', type: 'video' }, { src: 'http://example.com/video1.mp4', type: 'video', hasFullUrl: true }]}
         isOpen={this.state.lightboxIsOpen}
         onClickPrev={this.gotoPrevious}
         onClickNext={this.gotoNext}
@@ -109,3 +109,4 @@ src  | string | undefined | Required
 srcSet  | array of strings | undefined | Optional
 caption  | string | undefined | Optional
 alt  | string | undefined | Optional
+hasFullUrl  | boolean | undefined | Optional

--- a/README.md
+++ b/README.md
@@ -109,4 +109,3 @@ src  | string | undefined | Required
 srcSet  | array of strings | undefined | Optional
 caption  | string | undefined | Optional
 alt  | string | undefined | Optional
-hasFullUrl  | boolean | undefined | Optional

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -314,7 +314,7 @@ class Lightbox extends Component {
 
 			var width = Math.min(window.innerWidth - window.innerWidth / 5, 800);
 
-			const videoSrc = video.hasFullUrl
+			const videoSrc = video.src.startsWith("http://") || video.src.startsWith("https://")
 			 ? video.src
 			 : `//www.youtube.com/embed/${video.src}?rel=0&amp;showinfo=0;autoplay=1`;
 

--- a/src/Lightbox.js
+++ b/src/Lightbox.js
@@ -314,6 +314,10 @@ class Lightbox extends Component {
 
 			var width = Math.min(window.innerWidth - window.innerWidth / 5, 800);
 
+			const videoSrc = video.hasFullUrl
+			 ? video.src
+			 : `//www.youtube.com/embed/${video.src}?rel=0&amp;showinfo=0;autoplay=1`;
+
 			return (
 				<div key={video.src} id={video.src} className="video-item">
 					<iframe
@@ -322,9 +326,7 @@ class Lightbox extends Component {
 						type="text/html"
 						width={width}
 						height={(9 * width) / 16}
-						src={`//www.youtube.com/embed/${
-							video.src
-						}?rel=0&amp;showinfo=0;autoplay=1`}
+						src={videoSrc}
 						frameBorder="0"
 						allow="autoplay; encrypted-media"
 						allowFullScreen


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**

In addition to videos using Youtube videoId add support for direct video urls

**Related issues (if any):**


**Checks:**

- [x] Please confirm that only `/src` and `/examples/src` are committed
- [x] [if new feature] Please confirm that documentation was added to the README.md
